### PR TITLE
feature: implement isProduction 

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -29,6 +29,10 @@ class Config implements TypeSafeGetter {
 		return $this->sectionList[$sectionName] ?? null;
 	}
 
+	public function isProduction():bool {
+		return $this->getBool("app.production") ?? false;
+	}
+
 	protected function getSectionValue(string $name):?string {
 		$parts = explode(".", $name, 2);
 		$section = $this->getSection($parts[0]);

--- a/src/ConfigFactory.php
+++ b/src/ConfigFactory.php
@@ -51,6 +51,10 @@ class ConfigFactory {
 				$config = $config->withMerge($previousConfig);
 			}
 
+			if($file === "production") {
+				$config = self::withProductionFlag($config);
+			}
+
 			$previousConfig = $config;
 		}
 
@@ -64,5 +68,18 @@ class ConfigFactory {
 
 		$parser = new IniParser($pathName);
 		return $parser->parse();
+	}
+
+	protected static function withProductionFlag(Config $config):Config {
+		$appSection = $config->getSection("app");
+		if($appSection && $appSection->contains("production")) {
+			return $config;
+		}
+
+		return $config->withMerge(new Config(
+			new ConfigSection("app", [
+				"production" => "true",
+			])
+		));
 	}
 }

--- a/test/phpunit/ConfigFactoryConfigTest.php
+++ b/test/phpunit/ConfigFactoryConfigTest.php
@@ -34,6 +34,7 @@ class ConfigFactoryConfigTest extends ConfigTestCase {
 		self::assertEquals("this appears by default", $config->get("block1.value.existsByDefault"));
 		self::assertEquals("my.production.database", $config->get("database.host"));
 		self::assertEquals("example", $config->get("database.schema"));
+		self::assertTrue($config->isProduction());
 	}
 
 	public function testCreateFromPathName():void {
@@ -82,5 +83,26 @@ class ConfigFactoryConfigTest extends ConfigTestCase {
 		self::assertFalse($config->getBool("session.use_cookies"));
 		self::assertSame(0, $config->getInt("session.max_age"));
 		self::assertSame("", $config->getString("session.label"));
+	}
+
+	public function testCreateForProjectProductionFileDoesNotOverrideExplicitFlag():void {
+		$filePath = implode(DIRECTORY_SEPARATOR, [
+			$this->tmp,
+			"config.ini",
+		]);
+		$filePathProduction = implode(DIRECTORY_SEPARATOR, [
+			$this->tmp,
+			"config.production.ini",
+		]);
+
+		file_put_contents($filePath, implode(PHP_EOL, [
+			"[app]",
+			"production=false",
+			"",
+		]));
+		file_put_contents($filePathProduction, Helper::INI_OVERRIDE_PROD);
+
+		$config = ConfigFactory::createForProject($this->tmp);
+		self::assertFalse($config->isProduction());
 	}
 }

--- a/test/phpunit/ConfigTest.php
+++ b/test/phpunit/ConfigTest.php
@@ -67,6 +67,26 @@ class ConfigTest extends ConfigTestCase {
 		self::assertNull($sut->getFloat("nothing-here"));
 	}
 
+	public function testIsProductionDefaultsToFalse():void {
+		putenv("app_production");
+		$config = new Config();
+		self::assertFalse($config->isProduction());
+	}
+
+	public function testIsProductionUsesAppProductionValue():void {
+		putenv("app_production");
+		$config = new Config(
+			new ConfigSection("app", [
+				"production" => "0",
+			])
+		);
+		self::assertFalse($config->isProduction());
+
+		putenv("app_production=true");
+		self::assertTrue($config->isProduction());
+		putenv("app_production");
+	}
+
 	public function testWithMergeReturnsNewAndDoesNotMutateOriginal():void {
 		$original = new Config(
 			new ConfigSection("app", [


### PR DESCRIPTION
closes #229

This PR introduces a new boolean function on the `Config` class: `isProduction`.

To decide whether or not the app is in production mode, it first checks to see if there is a literal `app.production` variable in any config file. If there is no such variable, it uses the presence of the `config.production.ini` file to decide it is production.